### PR TITLE
Add ci, release and publish provider workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: GitHub Actions CI
+
+on:
+  push:
+    branches: [main]
+  pull_request: {}
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TEST_ORGANIZATION: 'gr-oss-terraform-provider'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - run: make tools
+      - run: make lint
+      - run: make build
+      - run: make test

--- a/.github/workflows/publish-provider.yml
+++ b/.github/workflows/publish-provider.yml
@@ -1,0 +1,104 @@
+name: Publish Terraform Provider
+
+on:
+  workflow_call:
+    secrets:
+      tfe_token:
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: publish
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract short version
+        id: extract_version
+        run: |
+          REF_NAME="${{ github.ref }}"
+          TAG_NAME="${REF_NAME#refs/tags/}"
+          FULL_VERSION="${TAG_NAME#v}"
+          SHORT_VERSION=$(echo "$FULL_VERSION" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          echo "short_version=$SHORT_VERSION" >> $GITHUB_ENV
+          echo "full_version=$FULL_VERSION" >> $GITHUB_ENV
+
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download v${{ env.full_version }} --repo ${{ github.repository }} --dir dist/
+
+      - name: Create version.json
+        run: |
+          cat <<EOF > version.json
+          {
+            "data": {
+              "type": "registry-provider-versions",
+              "attributes": {
+                "version": "${{ env.short_version }}",
+                "key-id": "${{ vars.TFE_KEY_ID }}",
+                "protocols": ["5.0"]
+              }
+            }
+          }
+          EOF
+
+      - name: Create provider version in Terraform Enterprise
+        id: create_version
+        env:
+          TOKEN: ${{ secrets.tfe_token }}
+        run: |
+          RESPONSE=$(curl -s -X POST \
+            --header "Authorization: Bearer $TOKEN" \
+            --header "Content-Type: application/vnd.api+json" \
+            --data @version.json \
+            https://app.terraform.io/api/v2/organizations/GR-OSS/registry-providers/private/GR-OSS/ranger/versions)
+
+          echo "shasums_upload=$(echo $RESPONSE | jq -r '.data.links."shasums-upload"')" >> $GITHUB_ENV
+          echo "shasums_sig_upload=$(echo $RESPONSE | jq -r '.data.links."shasums-sig-upload"')" >> $GITHUB_ENV
+
+      - name: Upload SHA256SUMS
+        run: |
+          curl -T dist/terraform-provider-ranger_${{ env.full_version }}_SHA256SUMS ${{ env.shasums_upload }}
+
+      - name: Upload SHA256SUMS.sig
+        run: |
+          curl -T dist/terraform-provider-ranger_${{ env.full_version }}_SHA256SUMS.sig ${{ env.shasums_sig_upload }}
+
+      - name: Process and Upload Provider Binaries
+        env:
+          TOKEN: ${{ secrets.tfe_token }}
+        run: |
+          for file in dist/*.zip; do
+          filename=$(basename "$file")
+          os=$(echo $filename | awk -F'_' '{print $(NF-1)}')
+          arch=$(echo $filename | awk -F'_' '{print $NF}' | sed 's/.zip//')
+          shasum=$(sha256sum $file | awk '{print $1}')
+
+          cat <<EOF > platform.json
+          {
+            "data": {
+              "type": "registry-provider-platforms",
+              "attributes": {
+                "os": "$os",
+                "arch": "$arch",
+                "shasum": "$shasum",
+                "filename": "$filename"
+              }
+            }
+          }
+          EOF
+
+          PLATFORM_RESPONSE=$(curl -s -X POST \
+            --header "Authorization: Bearer $TOKEN" \
+            --header "Content-Type: application/vnd.api+json" \
+            --data @platform.json \
+            https://app.terraform.io/api/v2/organizations/GR-OSS/registry-providers/private/GR-OSS/ranger/versions/${{ env.short_version }}/platforms)
+          
+          provider_binary_upload=$(echo $PLATFORM_RESPONSE | jq -r '.data.links."provider-binary-upload"')
+
+          curl -T "$file" "$provider_binary_upload"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+# Terraform Provider release workflow.
+name: Release
+
+# This GitHub action creates a release when a tag that matches the pattern
+# "v*" (e.g. v0.1.0) is created.
+on:
+  push:
+    tags:
+      - 'v*'
+
+# Releases need permissions to read and write the repository contents.
+# GitHub considers creating releases and uploading assets as writing contents.
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Allow goreleaser to access older tag information.
+          fetch-depth: 0
+
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
+        with:
+          args: release --clean
+          version: latest
+        env:
+          # GitHub sets the GITHUB_TOKEN secret automatically.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+
+  publish-provider:
+    needs: goreleaser
+    uses: ./.github/workflows/publish-provider.yml
+    secrets:
+      tfe_token: ${{ secrets.TFE_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,62 @@
+# Visit https://goreleaser.com for documentation on how to customize this
+# behavior.
+version: 2
+before:
+  hooks:
+    # this is just an example and not a requirement for provider building/publishing
+    - go mod tidy
+builds:
+  - env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like Terraform Cloud where
+      # they are unable to install libraries.
+      - CGO_ENABLED=0
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - "386"
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: "386"
+    binary: "{{ .ProjectName }}_v{{ .Version }}"
+archives:
+  - formats:
+      - zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+checksum:
+  extra_files:
+    - glob: "terraform-registry-manifest.json"
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      # if you are using this in a GitHub action or some other automated pipeline, you
+      # need to pass the batch flag to indicate its not interactive.
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+release:
+  extra_files:
+    - glob: "terraform-registry-manifest.json"
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+  # If you want to manually examine the release before its live, uncomment this line:
+  # draft: true
+changelog:
+  disable: true

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,8 @@
 default: fmt lint install generate
 
+tools:
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
+
 build:
 	go build -v ./...
 
@@ -21,4 +24,4 @@ test:
 testacc:
 	TF_ACC=1 go test -v -cover -timeout 120m ./...
 
-.PHONY: fmt lint test testacc build install generate
+.PHONY: fmt lint tools test testacc build install generate


### PR DESCRIPTION
## Description
This PR adds CI, release and publish workflows that run make targets, build the artifacts, run the goreleaser and publish the provider to GR-OSS HCP account provider registry

Briefly describe your changes:
- Added goreleaser config
- added CI workflow that runs make targets to install necessary tools, lint the code, build and test the code
- added Release workflow that runs on a tag push, runs the goreleaser to create artifacts and a Github release
- added Publish workflow that is invoked by the Release workflow, and runs with the given tag to create new version of the provider in HCP provider registry, with necessary artifacts

## Related Issue

Link to any related issue (if applicable): https://github.com/G-Research/gr-oss/issues/1084

## Checklist

- [x] Configure `publish` environment with secrets and vars set

## Reviewer Notes

Anything specific for reviewers to focus on?
N/A